### PR TITLE
Do not omit the identd position.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+ * Write dash in identd position
+
 ## [0.4.0] - 2017-03-30
 
 ### Added
@@ -28,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First version
 
+[Unreleased]: https://github.com/middlewares/access-log/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/middlewares/access-log/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/middlewares/access-log/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/middlewares/access-log/compare/v0.1.0...v0.2.0

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -124,8 +124,6 @@ class AccessLog implements MiddlewareInterface
      * Generates a message using the Apache's Common Log format
      * https://httpd.apache.org/docs/2.4/logs.html#accesslog.
      *
-     * Note: The user identifier (identd) is ommited intentionally
-     *
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
      *
@@ -141,7 +139,7 @@ class AccessLog implements MiddlewareInterface
         }
 
         return sprintf(
-            '%s %s [%s] "%s %s %s/%s" %d %d',
+            '%s - %s [%s] "%s %s %s/%s" %d %d',
             $ip,
             $request->getUri()->getUserInfo() ?: '-',
             strftime('%d/%b/%Y:%H:%M:%S %z'),


### PR DESCRIPTION
This info is missed, so a dash must be written in its position.

It represents the %l param of the Common Log format described in Apache documentation http://httpd.apache.org/docs/current/mod/mod_log_config.html