### PR TITLE
Write dash on empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+ * Write dash on empty body
+
 ## [0.4.1]
 
 ### Fixed
@@ -36,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First version
 
+[Unreleased]: https://github.com/middlewares/access-log/compare/v0.4.1...HEAD
 [0.4.1]: https://github.com/middlewares/access-log/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/middlewares/access-log/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/middlewares/access-log/compare/v0.2.0...v0.3.0

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -139,7 +139,7 @@ class AccessLog implements MiddlewareInterface
         }
 
         return sprintf(
-            '%s - %s [%s] "%s %s %s/%s" %d %d',
+            '%s - %s [%s] "%s %s %s/%s" %d %s',
             $ip,
             $request->getUri()->getUserInfo() ?: '-',
             strftime('%d/%b/%Y:%H:%M:%S %z'),
@@ -148,7 +148,7 @@ class AccessLog implements MiddlewareInterface
             strtoupper($request->getUri()->getScheme()),
             $request->getProtocolVersion(),
             $response->getStatusCode(),
-            $response->getBody()->getSize()
+            $response->getBody()->getSize() ?: '-'
         );
     }
 

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -35,8 +35,8 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
 
         $string = preg_replace('/\[[^\]]+\]/', '[date]', trim($string));
         $expect = <<<EOT
-[date] test.INFO: 0.0.0.0 - - [date] "GET /user/oscarotero/35 HTTP/1.1" 200 0 [] []
-[date] test.INFO: domain.com:80 - - - [date] "POST / HTTP/1.1" 200 0 [] []
+[date] test.INFO: 0.0.0.0 - - [date] "GET /user/oscarotero/35 HTTP/1.1" 200 - [] []
+[date] test.INFO: domain.com:80 - - - [date] "POST / HTTP/1.1" 200 - [] []
 EOT;
 
         $this->assertEquals($expect, $string);


### PR DESCRIPTION
In http://httpd.apache.org/docs/current/mod/mod_log_config.html#formats it states that:

**%b** | Size of response in bytes, excluding HTTP headers. In CLF format, i.e. a '-' rather than a 0 when no bytes are sent.