### PR TITLE
Refactorized the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-* Write dash on empty headers
+* Rewrited the middleware in order to be more flexible
+
+### Removed
+
+* The options `vhost` and `combined` are not longer available
+
+### Added
+
+* Option `hostnameLookups` to enable this flag
+* Option `format` to customize the message log format
+* New constants with predefined formats:
+  * `AccessLog::FORMAT_COMMON`
+  * `AccessLog::FORMAT_COMMON_VHOST`
+  * `AccessLog::FORMAT_COMBINED`
+  * `AccessLog::FORMAT_REFERER`
+  * `AccessLog::FORMAT_AGENT`
+  * `AccessLog::FORMAT_VHOST`
+  * `AccessLog::FORMAT_COMMON_DEBIAN`
+  * `AccessLog::FORMAT_COMBINED_DEBIAN`
+  * `AccessLog::FORMAT_VHOST_COMBINED_DEBIAN`
 
 ## [0.5.0] - 2017-04-03
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,25 @@ $response = $dispatcher->dispatch(new ServerRequest());
 
 The logger object used to store the logs.
 
-#### `combined($combined = true)`
+#### `format(string $format)`
 
-To use the *Combined Log* format instead the *Common Log* format. The *Combined Log* format is exactly the same than *Common Log,* with the addition of two more fields: `Referer` and `User-Agent` headers.
+Custom format used in the log message. [More info about the available options](http://httpd.apache.org/docs/2.4/mod/mod_log_config.html). You can use also one of the following constants provided with predefined formats:
+* `AccessLog::FORMAT_COMMON` (used by default)
+* `AccessLog::FORMAT_COMMON_VHOST`
+* `AccessLog::FORMAT_COMBINED`
+* `AccessLog::FORMAT_REFERER`
+* `AccessLog::FORMAT_AGENT`
+* `AccessLog::FORMAT_VHOST`
+* `AccessLog::FORMAT_COMMON_DEBIAN`
+* `AccessLog::FORMAT_COMBINED_DEBIAN`
+* `AccessLog::FORMAT_VHOST_COMBINED_DEBIAN`
 
-#### `vhost($vhost = true)`
-
-To prepend the virtual host info to the log record. [more info](https://httpd.apache.org/docs/2.4/logs.html#virtualhost)
+```php
+$dispatcher = new Dispatcher([
+    (new Middlewares\AccessLog($logger))
+        ->format(Middlewares\AccessLog::FORMAT_COMMON_VHOST)
+]);
+```
 
 #### `ipAttribute(string $ipAttribute)`
 
@@ -68,6 +80,10 @@ $dispatcher = new Dispatcher([
         ->ipAttribute('client-ip')
 ]);
 ```
+
+#### `hostnameLookups(bool $hostnameLookups = true)`
+
+Enable the `hostnameLookups` flag used to get the remote hostname (`%h`). (false by default)
 
 ---
 

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -94,13 +94,13 @@ class AccessLog implements MiddlewareInterface
     /**
      * Set the hostname lookups flag
      *
-     * @param bool $flag
+     * @param bool $hostnameLookups
      *
      * @return self
      */
-    public function hostnameLookups($flag = false)
+    public function hostnameLookups($hostnameLookups = true)
     {
-        $this->hostnameLookups = $flag;
+        $this->hostnameLookups = $hostnameLookups;
 
         return $this;
     }

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -219,7 +219,7 @@ class AccessLog implements MiddlewareInterface
                         return Format::getMessageSize($response, '-');
 
                     case 'S':
-                        return (Format::getMessageSize($request, 0) + Format::getMessageSize($response, 0)) ?: '-';
+                        return Format::getTransferredSize($request, $response);
 
                     //NOT IMPLEMENTED
                     case 'k':

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -10,10 +10,6 @@ use Psr\Log\LoggerInterface;
 
 class AccessLog implements MiddlewareInterface
 {
-    const FORMAT_COMMON = 1;
-    const FORMAT_COMBINED = 2;
-    const FORMAT_VHOST = 4;
-
     /**
      * @var LoggerInterface The router container
      */

--- a/src/AccessLogFormats.php
+++ b/src/AccessLogFormats.php
@@ -13,16 +13,16 @@ abstract class AccessLogFormats
 {
     /**
      * Client IP address of the request (%a)
-     * 
+     *
      * @param ServerRequestInterface $request
      * @param string|null $ipAttribute
-     * 
+     *
      * @return string
      */
     public static function getClientIp(ServerRequestInterface $request, $ipAttribute = null)
     {
         if (!empty($ipAttribute)) {
-            return $request->getAttribute($this->ipAttribute);
+            return $request->getAttribute($ipAttribute);
         }
 
         return self::getLocalIp($request);
@@ -30,9 +30,9 @@ abstract class AccessLogFormats
 
     /**
      * Local IP-address (%A)
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getLocalIp(ServerRequestInterface $request)
@@ -42,9 +42,9 @@ abstract class AccessLogFormats
 
     /**
      * Filename (%f)
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getFilename(ServerRequestInterface $request)
@@ -53,25 +53,25 @@ abstract class AccessLogFormats
     }
 
     /**
-     * Size of response in bytes, excluding HTTP headers (%B, %b)
-     * 
-     * @param ResponseInterface $response
+     * Size of the message in bytes, excluding HTTP headers (%B, %b)
+     *
+     * @param MessageInterface $message
      * @param string $default
-     * 
+     *
      * @return string
      */
-    public static function getResponseBodySize(ResponseInterface $response, $default)
+    public static function getBodySize(MessageInterface $message, $default)
     {
-        return (string) $response->getBody()->getSize() ?: '0';
+        return (string) $message->getBody()->getSize() ?: $default;
     }
 
     /**
      * Remote hostname (%h)
      * Will log the IP address if hostnameLookups is false.
-     * 
+     *
      * @param ServerRequestInterface $request
      * @param bool $hostnameLookups
-     * 
+     *
      * @return string
      */
     public static function getRemoteHostname(ServerRequestInterface $request, $hostnameLookups = false)
@@ -86,22 +86,22 @@ abstract class AccessLogFormats
     }
 
     /**
-     * The request protocol (%H)
-     * 
-     * @param ServerRequestInterface $request
-     * 
+     * The message protocol (%H)
+     *
+     * @param MessageInterface $message
+     *
      * @return string
      */
-    public static function getProtocol(ServerRequestInterface $request)
+    public static function getProtocol(MessageInterface $message)
     {
-        return 'HTTP/'.$request->getProtocolVersion();
+        return 'HTTP/'.$message->getProtocolVersion();
     }
 
     /**
      * The request method (%m)
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getMethod(ServerRequestInterface $request)
@@ -110,23 +110,69 @@ abstract class AccessLogFormats
     }
 
     /**
-     * The canonical port of the server serving the request. (%p)
-     * 
-     * @param ServerRequestInterface $request
-     * 
+     * Returns a message header
+     *
+     * @param MessageInterface $message
+     *
      * @return string
      */
-    public static function getPort(ServerRequestInterface $request)
+    public static function getHeader(MessageInterface $message, $name)
     {
-        return $request->getUri()->getPort() ?: ('https' === $request->getUri()->getScheme() ? 443 : 80);
+        return $message->getHeaderLine($name) ?: '-';
+    }
+
+    /**
+     * Returns a environment variable (%e)
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function getEnv($name)
+    {
+        return getenv($matches[1]) ?: '-';
+    }
+
+    /**
+     * Returns a cookie value (%{VARNAME}C)
+     *
+     * @param ServerRequestInterface $request
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function getCookie(ServerRequestInterface $request, $name)
+    {
+        $cookies = $request->getCookieParams();
+
+        return isset($cookies[$name]) ? $cookies[$name] : '-';
+    }
+
+    /**
+     * The canonical port of the server serving the request. (%p)
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string
+     */
+    public static function getPort(ServerRequestInterface $request, $format)
+    {
+        switch ($format) {
+            case 'canonical':
+            case 'local':
+                return $request->getUri()->getPort() ?: ('https' === $request->getUri()->getScheme() ? 443 : 80);
+
+            default:
+                return '-';
+        }
     }
 
     /**
      * The query string (%q)
      * (prepended with a ? if a query string exists, otherwise an empty string).
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getQuery(ServerRequestInterface $request)
@@ -138,9 +184,9 @@ abstract class AccessLogFormats
 
     /**
      * Status. (%s)
-     * 
+     *
      * @param ResponseInterface $response
-     * 
+     *
      * @return string
      */
     public static function getStatus(ResponseInterface $response)
@@ -150,9 +196,9 @@ abstract class AccessLogFormats
 
     /**
      * Remote user if the request was authenticated. (%u)
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getRemoteUser(ServerRequestInterface $request)
@@ -162,9 +208,9 @@ abstract class AccessLogFormats
 
     /**
      * The URL path requested, not including any query string. (%U)
-     * 
+     *
      * @param ServerRequestInterface $request
-     * 
+     *
      * @return string
      */
     public static function getPath(ServerRequestInterface $request)
@@ -179,7 +225,7 @@ abstract class AccessLogFormats
      *
      * @return string
      */
-    private function getHost(ServerRequestInterface $request)
+    public static function getHost(ServerRequestInterface $request)
     {
         $host = $request->hasHeader('Host') ? $request->getHeaderLine('Host') : $request->getUri()->getHost();
 
@@ -193,15 +239,165 @@ abstract class AccessLogFormats
      *
      * @return string
      */
-    private function getServerName(ServerRequestInterface $request)
+    public static function getServerName(ServerRequestInterface $request)
     {
         $name = self::getServerParam($request, 'SERVER_NAME');
 
         if ($name === '-') {
             return self::getHost($request);
         }
-        
+
         return $name;
+    }
+
+    /**
+     * First line of request. (%r)
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string
+     */
+    public static function getRequestLine(ServerRequestInterface $request)
+    {
+        return sprintf(
+            '%s %s%s %s',
+            self::getMethod($request),
+            self::getPath($request),
+            self::getQuery($request),
+            self::getProtocol($request)
+        );
+    }
+
+    /**
+     * Returns the response status line
+     *
+     * @param ResponseInterface $response
+     *
+     * @return string
+     */
+    public static function getResponseLine(ResponseInterface $response)
+    {
+        return sprintf(
+            '%s %d%s',
+            self::getProtocol($response),
+            self::getStatus($response),
+            ($response->getReasonPhrase() ? ' '.$response->getReasonPhrase() : '')
+        );
+    }
+
+    /**
+     * Returns the request size
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string
+     */
+    public static function getRequestSize(ServerRequestInterface $request)
+    {
+        $size = $this->getMessageSize($request, $this->getRequestFirstLine($request));
+        return null !== $size ? (string) $size : '-';
+
+        return sprintf(
+            '%s %d%s',
+            self::getProtocol($response),
+            self::getStatus($response),
+            ($response->getReasonPhrase() ? ' '.$response->getReasonPhrase() : '')
+        );
+    }
+
+    /**
+     * Get the message size (including first line and headers)
+     *
+     * @param MessageInterface $message
+     * @param mixed $default
+     *
+     * @return int|null
+     */
+    public static function getMessageSize(MessageInterface $message, $default = null)
+    {
+        $bodySize = $message->getBody()->getSize();
+
+        if (null === $bodySize) {
+            return $default;
+        }
+
+        $firstLine = '';
+
+        if ($message instanceof ServerRequestInterface) {
+            $firstLine = self::getRequestLine($message);
+        } elseif ($message instanceof ResponseInterface) {
+            $firstLine = self::getResponseLine($message);
+        }
+
+        $headers = [];
+
+        foreach ($message->getHeaders() as $header => $values) {
+            foreach ($values as $value) {
+                $headers[] = sprintf('%s: %s', $header, $value);
+            }
+        }
+
+        $headersSize = strlen(implode("\r\n", $headers));
+
+        return strlen($firstLine) + 2 + $headersSize + 4 + $bodySize;
+    }
+
+    /**
+     * Returns the request time (%t, %{format}t)
+     *
+     * @param float $begin
+     * @param float $end
+     * @param string $format
+     *
+     * @return string
+     */
+    public static function getRequestTime($begin, $end, $format)
+    {
+        $time = $begin;
+
+        if (strpos($format, 'begin:') === 0) {
+            $format = substr($format, 6);
+        } elseif (strpos($format, 'end:') === 0) {
+            $time = $end;
+            $format = substr($format, 4);
+        }
+
+        switch ($format) {
+            case 'sec':
+                return sprintf('[%s]', round($time));
+
+            case 'msec':
+                return sprintf('[%s]', round($time * 1E3));
+
+            case 'usec':
+                return sprintf('[%s]', round($time * 1E6));
+
+            default:
+                return sprintf('[%s]', strftime($format, $time));
+        }
+    }
+
+    /**
+     * The time taken to serve the request. (%T, %{format}T)
+     *
+     * @param float $begin
+     * @param float $end
+     * @param string $format
+     *
+     * @return string
+     */
+    public static function getRequestDuration($begin, $end, $format)
+    {
+        switch ($format) {
+            case 'us':
+                return (string) round(($end - $begin) * 1E6);
+
+            case 'ms':
+                return (string) round(($end - $begin) * 1E3);
+
+            default:
+                return (string) round($end - $begin);
+        }
     }
 
     /**

--- a/src/AccessLogFormats.php
+++ b/src/AccessLogFormats.php
@@ -49,7 +49,7 @@ abstract class AccessLogFormats
      */
     public static function getFilename(ServerRequestInterface $request)
     {
-        return $request->getServerParam($request, 'PHP_SELF');
+        return self::getServerParam($request, 'PHP_SELF');
     }
 
     /**
@@ -130,7 +130,7 @@ abstract class AccessLogFormats
      */
     public static function getEnv($name)
     {
-        return getenv($matches[1]) ?: '-';
+        return getenv($name) ?: '-';
     }
 
     /**
@@ -286,23 +286,16 @@ abstract class AccessLogFormats
     }
 
     /**
-     * Returns the request size
+     * Bytes transferred (received and sent), including request and headers (%S)
      *
      * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
      * @return string
      */
-    public static function getRequestSize(ServerRequestInterface $request)
+    public static function getTransferredSize(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $size = $this->getMessageSize($request, $this->getRequestFirstLine($request));
-        return null !== $size ? (string) $size : '-';
-
-        return sprintf(
-            '%s %d%s',
-            self::getProtocol($response),
-            self::getStatus($response),
-            ($response->getReasonPhrase() ? ' '.$response->getReasonPhrase() : '')
-        );
+        return (self::getMessageSize($request, 0) + self::getMessageSize($response, 0)) ?: '-';
     }
 
     /**

--- a/src/AccessLogFormats.php
+++ b/src/AccessLogFormats.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Middlewares;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Http\Message\MessageInterface;
+
+abstract class AccessLogFormats
+{
+    /**
+     * Client IP address of the request (%a)
+     * 
+     * @param ServerRequestInterface $request
+     * @param string|null $ipAttribute
+     * 
+     * @return string
+     */
+    public static function getClientIp(ServerRequestInterface $request, $ipAttribute = null)
+    {
+        if (!empty($ipAttribute)) {
+            return $request->getAttribute($this->ipAttribute);
+        }
+
+        return self::getLocalIp($request);
+    }
+
+    /**
+     * Local IP-address (%A)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getLocalIp(ServerRequestInterface $request)
+    {
+        return self::getServerParamIp($request, 'SERVER_ADDR');
+    }
+
+    /**
+     * Filename (%f)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getFilename(ServerRequestInterface $request)
+    {
+        return $request->getServerParam($request, 'PHP_SELF');
+    }
+
+    /**
+     * Size of response in bytes, excluding HTTP headers (%B, %b)
+     * 
+     * @param ResponseInterface $response
+     * @param string $default
+     * 
+     * @return string
+     */
+    public static function getResponseBodySize(ResponseInterface $response, $default)
+    {
+        return (string) $response->getBody()->getSize() ?: '0';
+    }
+
+    /**
+     * Remote hostname (%h)
+     * Will log the IP address if hostnameLookups is false.
+     * 
+     * @param ServerRequestInterface $request
+     * @param bool $hostnameLookups
+     * 
+     * @return string
+     */
+    public static function getRemoteHostname(ServerRequestInterface $request, $hostnameLookups = false)
+    {
+        $ip = self::getServerParamIp($request, 'REMOTE_ADDR');
+
+        if ($hostnameLookups && filter_var($ip, FILTER_VALIDATE_IP)) {
+            return gethostbyaddr($ip);
+        }
+
+        return $ip;
+    }
+
+    /**
+     * The request protocol (%H)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getProtocol(ServerRequestInterface $request)
+    {
+        return 'HTTP/'.$request->getProtocolVersion();
+    }
+
+    /**
+     * The request method (%m)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getMethod(ServerRequestInterface $request)
+    {
+        return strtoupper($request->getMethod());
+    }
+
+    /**
+     * The canonical port of the server serving the request. (%p)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getPort(ServerRequestInterface $request)
+    {
+        return $request->getUri()->getPort() ?: ('https' === $request->getUri()->getScheme() ? 443 : 80);
+    }
+
+    /**
+     * The query string (%q)
+     * (prepended with a ? if a query string exists, otherwise an empty string).
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getQuery(ServerRequestInterface $request)
+    {
+        $query = $request->getUri()->getQuery();
+
+        return '' !== $query ? '?'.$query : '';
+    }
+
+    /**
+     * Status. (%s)
+     * 
+     * @param ResponseInterface $response
+     * 
+     * @return string
+     */
+    public static function getStatus(ResponseInterface $response)
+    {
+        return (string) $response->getStatusCode();
+    }
+
+    /**
+     * Remote user if the request was authenticated. (%u)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getRemoteUser(ServerRequestInterface $request)
+    {
+        return self::getServerParam($request, 'REMOTE_USER');
+    }
+
+    /**
+     * The URL path requested, not including any query string. (%U)
+     * 
+     * @param ServerRequestInterface $request
+     * 
+     * @return string
+     */
+    public static function getPath(ServerRequestInterface $request)
+    {
+        return $request->getUri()->getPath() ?: '/';
+    }
+
+    /**
+     * The canonical ServerName of the server serving the request. (%v)
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string
+     */
+    private function getHost(ServerRequestInterface $request)
+    {
+        $host = $request->hasHeader('Host') ? $request->getHeaderLine('Host') : $request->getUri()->getHost();
+
+        return $host ?: '-';
+    }
+
+    /**
+     * The server name according to the UseCanonicalName setting. (%V)
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string
+     */
+    private function getServerName(ServerRequestInterface $request)
+    {
+        $name = self::getServerParam($request, 'SERVER_NAME');
+
+        if ($name === '-') {
+            return self::getHost($request);
+        }
+        
+        return $name;
+    }
+
+    /**
+     * Returns an server parameter value
+     *
+     * @param ServerRequestInterface $request
+     * @param string $key
+     * @param string $default
+     *
+     * @return string
+     */
+    private static function getServerParam(ServerRequestInterface $request, $key, $default = '-')
+    {
+        $server = $request->getServerParams();
+
+        return empty($server[$key]) ? $default : $server[$key];
+    }
+
+    /**
+     * Returns an ip from the server params
+     *
+     * @param ServerRequestInterface $request
+     * @param string $key
+     *
+     * @return string
+     */
+    private static function getServerParamIp(ServerRequestInterface $request, $key)
+    {
+        $ip = self::getServerParam($request, $key);
+
+        if (filter_var($ip, FILTER_VALIDATE_IP)) {
+            return $ip;
+        }
+
+        return '-';
+    }
+}

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -53,7 +53,7 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         }
 
         Dispatcher::run([
-            (new AccessLog($logger))->format(AccessLog::FORMAT_COMBINED)->ipAttribute('client-ip'),
+            (new AccessLog($logger))->format('%a %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"')->ipAttribute('client-ip'),
             function () {
                 return Factory::createResponse(503);
             }

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -50,8 +50,8 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         $string = preg_replace('/\[[^\]]+\]/', '[date]', trim($string));
         $expect = <<<EOT
 [date] test.INFO: 0.0.0.0 - - [date] "GET /user/oscarotero/35 HTTP/1.1" 200 - [] []
-[date] test.INFO: domain.com:443 - - - [date] "POST / HTTP/1.1" 200 12 [] []
-[date] test.INFO: domain.com:443 1.1.1.1 - - [date] "PUT / HTTP/1.1" 200 12 [] []
+[date] test.INFO: domain.com:443 - - [date] "POST / HTTP/1.1" 200 12 [] []
+[date] test.INFO: domain.com:443 - - [date] "PUT / HTTP/1.1" 200 12 [] []
 EOT;
 
         $this->assertEquals($expect, $string);

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -16,32 +16,48 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         $logger = new Logger('test');
         $logger->pushHandler(new StreamHandler($logs));
 
-        $request = Factory::createServerRequest([
-            'REMOTE_ADDR' => '0.0.0.0'
-        ], 'GET', 'http://domain.com/user/oscarotero/35');
-        $request2 = Factory::createServerRequest([], 'POST', 'https://domain.com');
-        $request3 = Factory::createServerRequest([], 'PUT', 'https://domain.com')
-            ->withAttribute('client-ip', '1.1.1.1');
+        $request = Factory::createServerRequest(
+            ['REMOTE_ADDR' => '0.0.0.0' ],
+            'GET',
+            'http://example.com/user'
+        )
+        ->withHeader('Referer', 'http://example.org')
+        ->withHeader('User-Agent', 'curl/7');
 
         Dispatcher::run([
             new AccessLog($logger),
+            function () {
+                echo 'some content';
+            }
         ], $request);
 
-        Dispatcher::run([
-            (new AccessLog($logger))->vhost(),
-            function () {
-                echo 'some content';
-            }
-        ], $request2);
+        $formats = [
+            AccessLog::FORMAT_COMMON,
+            AccessLog::FORMAT_COMMON_VHOST,
+            AccessLog::FORMAT_COMBINED,
+            AccessLog::FORMAT_REFERER,
+            AccessLog::FORMAT_AGENT,
+            AccessLog::FORMAT_VHOST,
+            AccessLog::FORMAT_COMMON_DEBIAN,
+            AccessLog::FORMAT_COMBINED_DEBIAN,
+            AccessLog::FORMAT_VHOST_COMBINED_DEBIAN,
+        ];
+
+        foreach ($formats as $format) {
+            Dispatcher::run([
+                (new AccessLog($logger))->format($format),
+                function () {
+                    echo 'some content';
+                }
+            ], $request);
+        }
 
         Dispatcher::run([
-            (new AccessLog($logger))
-                ->vhost()
-                ->ipAttribute('client-ip'),
+            (new AccessLog($logger))->format(AccessLog::FORMAT_COMBINED)->ipAttribute('client-ip'),
             function () {
-                echo 'some content';
+                return Factory::createResponse(503);
             }
-        ], $request3);
+        ], Factory::createServerRequest([], 'PUT', 'https://domain.com')->withAttribute('client-ip', '1.1.1.1'));
 
         rewind($logs);
 
@@ -49,9 +65,17 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
 
         $string = preg_replace('/\[[^\]]+\]/', '[date]', trim($string));
         $expect = <<<EOT
-[date] test.INFO: 0.0.0.0 - - [date] "GET /user/oscarotero/35 HTTP/1.1" 200 - [] []
-[date] test.INFO: domain.com:443 - - [date] "POST / HTTP/1.1" 200 12 [] []
-[date] test.INFO: domain.com:443 - - [date] "PUT / HTTP/1.1" 200 12 [] []
+[date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: example.com 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 "http://example.org" "curl/7" [] []
+[date] test.INFO: http://example.org -> /user [] []
+[date] test.INFO: curl/7 [] []
+[date] test.INFO: example.com - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 [] []
+[date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://example.org” “curl/7” [] []
+[date] test.INFO: example.com:80 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://example.org” “curl/7" [] []
+[date] test.ERROR: 1.1.1.1 - - [date] "PUT / HTTP/1.1" 503 - "-" "-" [] []
 EOT;
 
         $this->assertEquals($expect, $string);

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -19,9 +19,9 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         $request = Factory::createServerRequest(
             ['REMOTE_ADDR' => '0.0.0.0' ],
             'GET',
-            'http://example.com/user'
+            'http://hello.co/user'
         )
-        ->withHeader('Referer', 'http://example.org')
+        ->withHeader('Referer', 'http://hello.org')
         ->withHeader('User-Agent', 'curl/7');
 
         Dispatcher::run([
@@ -53,7 +53,10 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         }
 
         Dispatcher::run([
-            (new AccessLog($logger))->format('%a %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"')->ipAttribute('client-ip'),
+            (new AccessLog($logger))
+                ->format('%a %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"')
+                ->ipAttribute('client-ip'),
+
             function () {
                 return Factory::createResponse(503);
             }
@@ -67,14 +70,14 @@ class AccessLogTest extends \PHPUnit_Framework_TestCase
         $expect = <<<EOT
 [date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
 [date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
-[date] test.INFO: example.com 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
-[date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 "http://example.org" "curl/7" [] []
-[date] test.INFO: http://example.org -> /user [] []
+[date] test.INFO: hello.co 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 200 12 "http://hello.org" "curl/7" [] []
+[date] test.INFO: http://hello.org -> /user [] []
 [date] test.INFO: curl/7 [] []
-[date] test.INFO: example.com - - [date] "GET /user HTTP/1.1" 200 12 [] []
+[date] test.INFO: hello.co - - [date] "GET /user HTTP/1.1" 200 12 [] []
 [date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 [] []
-[date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://example.org” “curl/7” [] []
-[date] test.INFO: example.com:80 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://example.org” “curl/7" [] []
+[date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://hello.org” “curl/7” [] []
+[date] test.INFO: hello.co:80 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://hello.org” “curl/7" [] []
 [date] test.ERROR: 1.1.1.1 - - [date] "PUT / HTTP/1.1" 503 - "-" "-" [] []
 EOT;
 


### PR DESCRIPTION
This change uses `strtr` instead `sprintf` to generate the messages, providing more flexibility to customize the output format.
It also fixes some bugs like append the uri's query to the path or replace `%h` value (ip) by `%v` (virtual host) instead prepend it.