### PR TITLE
Add support to log request attributes

### DIFF
--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -267,6 +267,9 @@ class AccessLog implements MiddlewareInterface
                     case 'i':
                         return Format::getHeader($request, $matches[1]);
 
+                    case 'n':
+                        return Format::getAttribute($request, $matches[1]);
+
                     case 'o':
                         return Format::getHeader($response, $matches[1]);
 
@@ -280,7 +283,6 @@ class AccessLog implements MiddlewareInterface
                         return Format::getRequestDuration($begin, $end, $matches[1]);
 
                     //NOT IMPLEMENTED
-                    case 'n':
                     case 'P':
                     default:
                         return '-';

--- a/src/AccessLogFormats.php
+++ b/src/AccessLogFormats.php
@@ -19,7 +19,7 @@ abstract class AccessLogFormats
     public static function getClientIp(ServerRequestInterface $request, $ipAttribute = null)
     {
         if (!empty($ipAttribute)) {
-            return $request->getAttribute($ipAttribute);
+            return self::getAttribute($request, $ipAttribute);
         }
 
         return self::getLocalIp($request);
@@ -388,6 +388,19 @@ abstract class AccessLogFormats
             default:
                 return (string) round($end - $begin);
         }
+    }
+
+    /**
+     * Returns a server request attribute
+     *
+     * @param ServerRequestInterface $request
+     * @param string $key
+     *
+     * @return string
+     */
+    public static function getAttribute(ServerRequestInterface $request, $key)
+    {
+        return $request->getAttribute($key, '-');
     }
 
     /**

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -138,5 +138,6 @@ EOT;
         $this->assertEquals('100', Format::getRequestDuration(100, 200, 'sec'));
         $this->assertEquals('100000', Format::getRequestDuration(100, 200, 'ms'));
         $this->assertEquals('100000000', Format::getRequestDuration(100, 200, 'us'));
+        $this->assertEquals('1.2.3.4', Format::getAttribute($request, 'client-ip'));
     }
 }


### PR DESCRIPTION
In Apache, the main use for [notes](http://php.net/manual/en/function.apache-note.php) is to pass information from one module to another within the same request. These notes can be logged using the `%{}n` pattern, currently not implemented in this middleware.

In a similar way, the PSR-7 Server Request provide the `attributes` array to inject parameters that can be passed to another middleware. As I need to log some of these attributes, I think we can reuse this pattern to log attributes.

What do you think?