### PR TITLE
Use different severity for client errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use `phpstan` as a dev dependency to detect bugs
 
+### Added
+
+- Improved usage of log levels, allowing people to have more control on what goes
+  into their production log handler
+
 ## [1.1.0] - 2018-08-04
 
 ### Added

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -126,7 +126,11 @@ class AccessLog implements MiddlewareInterface
             $context = $contextFunction($request, $response);
         }
 
-        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode >= 400 && $statusCode < 500) {
+            $this->logger->warning($message, $context);
+        } elseif ($statusCode >= 500 && $statusCode < 600) {
             $this->logger->error($message, $context);
         } else {
             $this->logger->info($message, $context);

--- a/tests/AccessLogTest.php
+++ b/tests/AccessLogTest.php
@@ -67,6 +67,14 @@ class AccessLogTest extends TestCase
             },
         ], Factory::createServerRequest('PUT', 'https://domain.com')->withAttribute('client-ip', '1.1.1.1'));
 
+        Dispatcher::run([
+            new AccessLog($logger),
+
+            function () {
+                return Factory::createResponse(404);
+            },
+        ], $request);
+
         rewind($logs);
 
         $string = stream_get_contents($logs);
@@ -84,6 +92,7 @@ class AccessLogTest extends TestCase
 [date] test.INFO: 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://hello.org” “curl/7” [] []
 [date] test.INFO: hello.co:80 0.0.0.0 - - [date] “GET /user HTTP/1.1” 200 33 “http://hello.org” “curl/7" [] []
 [date] test.ERROR: 1.1.1.1 - - [date] "PUT / HTTP/1.1" 503 - "-" "-" [] []
+[date] test.WARNING: 0.0.0.0 - - [date] "GET /user HTTP/1.1" 404 - [] []
 EOT;
 
         $this->assertEquals($expect, $string);


### PR DESCRIPTION
**Important:** this should probably be considered as a BC-breaking change, since log severity will change.

The `ERROR` severity in logs is used for things that developers MUST track and fix when possible. However, the 4xx status codes are related to client mistakes - and the API developers are usually unable to solve.

By using `WARNING` for 4xx we allow users of this middleware to have the opportunity to fine-tune their production logging and potentially ignore client errors.