### PR TITLE
AccessLog: added 3rd argument to context function: $message

### DIFF
--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -123,7 +123,7 @@ class AccessLog implements MiddlewareInterface
 
         if ($this->context !== null) {
             $contextFunction = $this->context;
-            $context = $contextFunction($request, $response);
+            $context = $contextFunction($request, $response, $message);
         }
 
         $statusCode = $response->getStatusCode();


### PR DESCRIPTION
For some structured logs, there may be a need to use the original message - which is not currently possible. Using this simple change, we can use the original message and not create it again manually.

An example: when using [ECS logging](https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html), we may need to put the original message `127.0.0.1 - - [01/Apr/2022:10:28:41 +0100] \"GET / HTTP/1.1\" 200 -` into another field. Using elastic [ECS logging](https://github.com/elastic/ecs-logging-php), the target result shall be similar to:

```json
{
    "@timestamp": "2022-04-01T10:28:41.800328+00:00",
    "ecs.version": "1.2.0",
    "log.level": "INFO",
    "message": "127.0.0.1 - - [01/Apr/2022:10:28:41 +0100] \"GET / HTTP/1.1\" 200 -",
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:98.0) Gecko/20100101 Firefox/98.0",
    "event" {
        "original": "127.0.0.1 - - [01/Apr/2022:10:28:41 +0100] \"GET / HTTP/1.1\" 200 -"
    }
    ...
}
```

Currently, the `event.original` field is not possible to create. With this PR it is quite simple:

```php
$middleware = new AccessLog();
$middleware->context(function(ServerRequestInterface $request, ResponseInterface $response, string $message): array {
	return [
		'user_agent' => $request->getHeaderLine('User-Agent'),
		'event' => [
			'type' => 'access',
			'original' => $message,
		],
	];
});
```