### PR TITLE
Fix message size return when body size is unknown

### DIFF
--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -191,9 +191,11 @@ class AccessLog implements MiddlewareInterface
                     case 'V':
                         return Format::getServerName($request);
                     case 'I':
-                        return Format::getMessageSize($request, '-');
+                        $messageSize = Format::getMessageSize($request);
+                        return null === $messageSize ? '-' : (string) $messageSize;
                     case 'O':
-                        return Format::getMessageSize($response, '-');
+                        $messageSize = Format::getMessageSize($response);
+                        return null === $messageSize ? '-' : (string) $messageSize;
                     case 'S':
                         return Format::getTransferredSize($request, $response);
                     //NOT IMPLEMENTED

--- a/src/AccessLogFormats.php
+++ b/src/AccessLogFormats.php
@@ -216,7 +216,7 @@ abstract class AccessLogFormats
      *
      * @param mixed $default
      */
-    public static function getMessageSize(MessageInterface $message, $default = null): ?int
+    public static function getMessageSize(MessageInterface $message, int $default = null): ?int
     {
         $bodySize = $message->getBody()->getSize();
 


### PR DESCRIPTION
When the body size of a message is unknown, the current code throws the following error:

> Uncaught TypeError: Return value of Middlewares\AccessLogFormats::getMessageSize() must be of the type int or null, string returned

This patch fixes it.